### PR TITLE
added more combinations for gputogpu transfers

### DIFF
--- a/src/cudaMemcpyAsync/gpu_to_gpu_nopeer.cpp
+++ b/src/cudaMemcpyAsync/gpu_to_gpu_nopeer.cpp
@@ -85,7 +85,7 @@ auto Comm_cudaMemcpyAsync_GPUToGPU = [](benchmark::State &state, const int numa_
 static void registerer() {
   std::string name;
   for (size_t i = 0; i < unique_cuda_device_ids().size(); ++i) {
-    for (size_t j = i + 1; j < unique_cuda_device_ids().size(); ++j) {
+    for (size_t j = 0; j < unique_cuda_device_ids().size(); ++j) {
       auto src_gpu = unique_cuda_device_ids()[i];
       auto dst_gpu = unique_cuda_device_ids()[j];
       for (auto numa_id : numa::ids()) {

--- a/src/cudaMemcpyAsync/gpu_to_gpu_peer.cpp
+++ b/src/cudaMemcpyAsync/gpu_to_gpu_peer.cpp
@@ -64,7 +64,7 @@ auto Comm_Memcpy_GPUToGPUPeer = [](benchmark::State &state, const int src_gpu,
 static void registerer() {
   std::string name;
   for (size_t i = 0; i < unique_cuda_device_ids().size(); ++i) {
-    for (size_t j = i + 1; j < unique_cuda_device_ids().size(); ++j) {
+    for (size_t j = 0; j < unique_cuda_device_ids().size(); ++j) {
       auto src_gpu = unique_cuda_device_ids()[i];
       auto dst_gpu = unique_cuda_device_ids()[j];
       int s2d, d2s;

--- a/src/cudaMemcpyPeerAsync/gpu_to_gpu_peer.cpp
+++ b/src/cudaMemcpyPeerAsync/gpu_to_gpu_peer.cpp
@@ -71,7 +71,7 @@ auto Comm_cudaMemcpyPeerAsync_GPUToGPUPeer = [](benchmark::State &state,
 
 static void registerer() {
   for (size_t i = 0; i < unique_cuda_device_ids().size(); ++i) {
-    for (size_t j = i; j < unique_cuda_device_ids().size(); ++j) {
+    for (size_t j = 0; j < unique_cuda_device_ids().size(); ++j) {
       auto srcGpu = unique_cuda_device_ids()[i];
       auto dstGpu = unique_cuda_device_ids()[j];
       int s2d, d2s;

--- a/src/zerocopy/gpu_to_gpu.cu
+++ b/src/zerocopy/gpu_to_gpu.cu
@@ -94,7 +94,7 @@ static void registerer() {
   for (auto workload : {READ, WRITE}) {
     for (auto src_gpu : unique_cuda_device_ids()) {
       for (auto dst_gpu : unique_cuda_device_ids()) {
-        if (src_gpu < dst_gpu) {
+        {
 
           int s2d = false;
           int d2s = false;

--- a/src/zerocopy/kernels.hu
+++ b/src/zerocopy/kernels.hu
@@ -30,6 +30,7 @@ __global__ void gpu_write(write_t *ptr, const size_t bytes) {
   const size_t num_elems = bytes / sizeof(write_t);
 
   for (size_t i = gx; i < num_elems; i += gridDim.x * BD) {
+    __syncthreads();
     ptr[i] = 0;
   }
 }


### PR DESCRIPTION
For more complicated topologies (ie. multiple PCIe switches and host bridges), it is helpful to have all pairs of GPUs benchmarkable as we noticed different paths experience different performance behavior. For example, we have a GPU connected to the host bridge directly and another GPU connected to a PCIe Switch, the bandwidth between the 2 in each direction can be different.
So I enabled all pairs of GPU for some of the GPU-To-GPU benchmarks.

Also, added a block sync for direct access write benchmark for improved bandwidth utilization.